### PR TITLE
[rfcs] fixes inline syntax highlighting

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -68,6 +68,41 @@ exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store', "rfc/0000-template.rst"
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
+# Prepended to all .rst files when rendering them.
+rst_prolog = """
+.. role:: python(code)
+   :language: python
+   :class: highlight
+
+.. role:: scala(code)
+   :language: scala
+   :class: highlight
+
+.. role:: c(code)
+   :language: cpp
+   :class: highlight
+
+.. role:: cpp(code)
+   :language: cpp
+   :class: highlight
+
+.. role:: html(code)
+   :language: html
+   :class: highlight
+
+.. role:: css(code)
+   :language: css
+   :class: highlight
+
+.. role:: scss(code)
+   :language: scss
+   :class: highlight
+
+.. role:: javascript(code)
+   :language: javascript
+   :class: highlight
+
+"""
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/rfc/0000-template.rst
+++ b/rfc/0000-template.rst
@@ -3,7 +3,9 @@ Notes on reStructuredText - delete this section before submitting
 
 The proposals are submitted in reStructuredText format.
 To get inline code, enclose text in double backticks, ``like this``, or include
-inline syntax highlighting [scala]`like this`.
+inline syntax highlighting :scala:`"like this"`. For the latter, if you are
+using a language that hasn't yet been used elsewhere in the RFCs, you'll need to
+add a ``role`` to the ``rst_prolog`` variable in ``conf.py``.
 To get block code, use a double colon and indent by at least one space
 
 ::


### PR DESCRIPTION
Note that inline syntax highlighting for `.rst` files is not supported when previewing them on GitHub, and to view the actual effect of this change locally, you need to apply this diff:
```diff
diff --git a/conf.py b/conf.py
index 85c8017..0779aa2 100644
--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store', "rfc/0000-template.rst"]
+exclude_patterns = [u'_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
```
and then run `make html` and view `_build/html/index.html` in your browser.