### PR TITLE
[batch] Add Batch job metadata server

### DIFF
--- a/rfc/0000-keyless-job-auth.rst
+++ b/rfc/0000-keyless-job-auth.rst
@@ -46,9 +46,9 @@ to 90 days.
 
 Cloud providers avoid persisting long-lived credentials on user machines through
 the Metadata Server interface, an HTTP endpoint available on a
-`link-local https://en.wikipedia.org/wiki/Link-local_address`_ address which can
+`link-local <https://en.wikipedia.org/wiki/Link-local_address>`_ address which can
 issue access tokens for the identity assigned to the virtual machine. Available
-metadata in GCP is described [here](https://cloud.google.com/compute/docs/metadata/predefined-metadata-keys). This interface has the following advantages:
+metadata in GCP is described `here <https://cloud.google.com/compute/docs/metadata/predefined-metadata-keys>`_. This interface has the following advantages:
 
 - Unlike long-lived keys, these tokens are short-lived (e.g. 1 hour), reducing
   the potential attack window following exfiltration.
@@ -90,76 +90,80 @@ the same in Azure.
 Current System
 ==============
 
-+-----+                                                +-----+              +-----+
-| Job |                                                | IAM |              | GCS |
-+-----+                                                +-----+              +-----+
-   | --------------------------------------------------\  |                    |
-   |-| Cook up request for access token using key file |  |                    |
-   | |-------------------------------------------------|  |                    |
-   |                                                      |                    |
-   | https://www.googleapis.com/oauth2/v4/token           |                    |
-   |----------------------------------------------------->|                    |
-   |                                                      | ----------------\  |
-   |                                                      |-| Validate key  |  |
-   |                                                      | |---------------|  |
-   |                                                      |                    |
-   |                          Access Token scoped for GCS |                    |
-   |<-----------------------------------------------------|                    |
-   |                                                      |                    |
-   | Access Token                                         |                    |
-   |-------------------------------------------------------------------------->|
-   |                                                      |                    | -----------------------------------\
-   |                                                      |                    |-| Validate access token and scopes |
-   |                                                      |                    | |----------------------------------|
-   |                                                      |                    |
-   |                                                      |               File |
-   |<--------------------------------------------------------------------------|
-   |                                                      |                    |
+.. code-block:: text
+
+    +-----+                                                +-----+              +-----+
+    | Job |                                                | IAM |              | GCS |
+    +-----+                                                +-----+              +-----+
+       | --------------------------------------------------\  |                    |
+       |-| Cook up request for access token using key file |  |                    |
+       | |-------------------------------------------------|  |                    |
+       |                                                      |                    |
+       | https://www.googleapis.com/oauth2/v4/token           |                    |
+       |----------------------------------------------------->|                    |
+       |                                                      | ----------------\  |
+       |                                                      |-| Validate key  |  |
+       |                                                      | |---------------|  |
+       |                                                      |                    |
+       |                          Access Token scoped for GCS |                    |
+       |<-----------------------------------------------------|                    |
+       |                                                      |                    |
+       | Access Token                                         |                    |
+       |-------------------------------------------------------------------------->|
+       |                                                      |                    | -----------------------------------\
+       |                                                      |                    |-| Validate access token and scopes |
+       |                                                      |                    | |----------------------------------|
+       |                                                      |                    |
+       |                                                      |               File |
+       |<--------------------------------------------------------------------------|
+       |                                                      |                    |
 
 
 Proposed Model
 ==============
 
-+-----+                                                                                +---------+                                              +-----+              +-----+
-| Job |                                                                                | Worker  |                                              | IAM |              | GCS |
-+-----+                                                                                +---------+                                              +-----+              +-----+
-   |                                                                                        |                                                      |                    |
-   | http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token      |                                                      |                    |
-   |--------------------------------------------------------------------------------------->|                                                      |                    |
-   |                                                                                        | --------------------------------------------------\  |                    |
-   |                                                                                        |-| Cook up request for access token using key file |  |                    |
-   |                                                                                        | |-------------------------------------------------|  |                    |
-   |                                                                                        |                                                      |                    |
-   |                                                                                        | https://www.googleapis.com/oauth2/v4/token           |                    |
-   |                                                                                        |----------------------------------------------------->|                    |
-   |                                                                                        |                                                      | ----------------\  |
-   |                                                                                        |                                                      |-| Validate key  |  |
-   |                                                                                        |                                                      | |---------------|  |
-   |                                                                                        |                                                      |                    |
-   |                                                                                        |                          Access Token scoped for GCS |                    |
-   |                                                                                        |<-----------------------------------------------------|                    |
-   |                                                                                        |                                                      |                    |
-   |                                                                           Access Token |                                                      |                    |
-   |<---------------------------------------------------------------------------------------|                                                      |                    |
-   |                                                                                        |                                                      |                    |
-   | Access Token                                                                           |                                                      |                    |
-   |------------------------------------------------------------------------------------------------------------------------------------------------------------------->|
-   |                                                                                        |                                                      |                    | -----------------------------------\
-   |                                                                                        |                                                      |                    |-| Validate access token and scopes |
-   |                                                                                        |                                                      |                    | |----------------------------------|
-   |                                                                                        |                                                      |                    |
-   |                                                                                        |                                                      |               File |
-   |<-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-   |                                                                                        |                                                      |                                      |
+.. code-block:: text
+
+    +-----+                                                                                +---------+                                              +-----+              +-----+
+    | Job |                                                                                | Worker  |                                              | IAM |              | GCS |
+    +-----+                                                                                +---------+                                              +-----+              +-----+
+       |                                                                                        |                                                      |                    |
+       | http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token      |                                                      |                    |
+       |--------------------------------------------------------------------------------------->|                                                      |                    |
+       |                                                                                        | --------------------------------------------------\  |                    |
+       |                                                                                        |-| Cook up request for access token using key file |  |                    |
+       |                                                                                        | |-------------------------------------------------|  |                    |
+       |                                                                                        |                                                      |                    |
+       |                                                                                        | https://www.googleapis.com/oauth2/v4/token           |                    |
+       |                                                                                        |----------------------------------------------------->|                    |
+       |                                                                                        |                                                      | ----------------\  |
+       |                                                                                        |                                                      |-| Validate key  |  |
+       |                                                                                        |                                                      | |---------------|  |
+       |                                                                                        |                                                      |                    |
+       |                                                                                        |                          Access Token scoped for GCS |                    |
+       |                                                                                        |<-----------------------------------------------------|                    |
+       |                                                                                        |                                                      |                    |
+       |                                                                           Access Token |                                                      |                    |
+       |<---------------------------------------------------------------------------------------|                                                      |                    |
+       |                                                                                        |                                                      |                    |
+       | Access Token                                                                           |                                                      |                    |
+       |------------------------------------------------------------------------------------------------------------------------------------------------------------------->|
+       |                                                                                        |                                                      |                    | -----------------------------------\
+       |                                                                                        |                                                      |                    |-| Validate access token and scopes |
+       |                                                                                        |                                                      |                    | |----------------------------------|
+       |                                                                                        |                                                      |                    |
+       |                                                                                        |                                                      |               File |
+       |<-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+       |                                                                                        |                                                      |                    |
 
 
 It is worth emphasizing that the purpose of this feature is *not* to provide a
 fully complete and compliant metadata server to Hail Batch. Rather, the aim is to provide the
 minimum functionality necessary to allow Hail libraries and popular first-party
-tools like `gcloud` and `az` the ability to obtain short-lived credentials without
+tools like ``gcloud`` and ``az`` the ability to obtain short-lived credentials without
 exposing key files to user code. As such, an implementation may implement just the
-endpoints necessary to run the below examples for at least one version of `gcloud`/`az`
-and all supported versions of `hail`.
+endpoints necessary to run the below examples for at least one version of ``gcloud``/``az``
+and all supported versions of ``hail``.
 
 
 Examples
@@ -168,6 +172,7 @@ Examples
 Under the proposed change, the following Batch job commands should succeed:
 
 .. code-block:: python
+
    j.command('gcloud storage ls <MY_BUCKET>')
    j.command('hailctl batch submit <MY_SCRIPT>')
 
@@ -189,16 +194,16 @@ Inspiration & Alternatives
 --------------------------
 
 We can look to the Kubernetes project for examples of integrating with cloud
-identity providers. In particular, we will examine [GKE's Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#what_is).
+identity providers. In particular, we will examine `GKE's Workload Identity <https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#what_is>`_.
 Workload identity allows pods to obtain credentials for GCP IAM identities. To
-do so, GKE runs the [GKE Metadata Server](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#metadata_server)
+do so, GKE runs the `GKE Metadata Server <https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#metadata_server>`_
 which functions similarly to what is described in this proposal.
 
 The difference arises in how the metadata server fulfills the user's request for
 an access token. Unlike in this proposal, GKE nodes do not hold IAM credentials.
 Instead, it uses OIDC to "trade" a Kubernetes Service Account credential for a
-[preconfigured IAM credential](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#credential-flow). This has the advantage of not needing to distribute IAM
+`preconfigured IAM credential <https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#credential-flow>`_. This has the advantage of not needing to distribute IAM
 credentials in GKE and enabling fine-grained mapping between GKE and IAM identities.
 However, OIDC is not easily applicable in Hail Batch because Batch is not an
 identity provider. We could remove the storage and distribution of key files in GCP by
-using [IAM Service Account Impersonation](https://cloud.google.com/docs/authentication/use-service-account-impersonation), but that is outside the scope of this RFC.
+using `IAM Service Account Impersonation <https://cloud.google.com/docs/authentication/use-service-account-impersonation>`_, but that is outside the scope of this RFC.

--- a/rfc/0000-keyless-job-auth.rst
+++ b/rfc/0000-keyless-job-auth.rst
@@ -1,0 +1,102 @@
+===============================================
+Keyless Cloud Authentication in Hail Batch Jobs
+===============================================
+
+.. author:: Daniel Goldstein
+.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
+.. ticket-url:: Leave blank. This will eventually be filled with the
+                ticket URL which will track the progress of the
+                implementation of the feature.
+.. implemented:: Leave blank. This will be filled in with the first Hail version which
+                 implements the described feature.
+.. header:: This proposal is `discussed at this pull request <https://github.com/hail-is/hail-rfc/pull/0>`_.
+            **After creating the pull request, edit this file again, update the
+            number in the link, and delete this bold sentence.**
+.. sectnum::
+.. contents::
+.. role::
+
+Motivation
+----------
+Give a strong reason for why the community needs this change. Describe the use
+case as clearly as possible and give an example. Explain how the status quo is
+insufficient or not ideal.
+
+A good Motivation section is often driven by examples and real-world scenarios.
+
+Proposed Change Specification
+-----------------------------
+Specify the change in precise, comprehensive yet concise language. Avoid words
+like "should" or "could". Strive for a complete definition. Your specification
+may include,
+
+* the types and semantics of any new library interfaces
+* how the proposed change interacts with existing language or compiler
+  features, in case that is otherwise ambiguous
+
+Strive for *precision*. Note, however, that this section should focus on a
+precise *specification*; it need not (and should not) devote space to
+*implementation* details -- the "Implementation Plan" section can be used for
+that.
+
+The specification can, and almost always should, be illustrated with
+*examples* that illustrate corner cases. But it is not sufficient to
+give a couple of examples and regard that as the specification! The
+examples should illustrate and elucidate a clearly-articulated
+specification that covers the general case.
+
+Examples
+--------
+This section illustrates the specification through the use of examples of the
+language change proposed. It is best to exemplify each point made in the
+specification, though perhaps one example can cover several points. Contrived
+examples are OK here. If the Motivation section describes something that is
+hard to do without this proposal, this is a good place to show how easy that
+thing is to do with the proposal.
+
+Effect and Interactions
+-----------------------
+Your proposed change addresses the issues raised in the motivation. Explain how.
+
+Also, discuss possibly contentious interactions with existing language or compiler
+features. Complete this section with potential interactions raised
+during the PR discussion.
+
+Costs and Drawbacks
+-------------------
+Give an estimate on development and maintenance costs. List how this affects
+learnability of the language for novice users. Define and list any remaining
+drawbacks that cannot be resolved.
+
+Alternatives
+------------
+List alternative designs to your proposed change. Both existing
+workarounds, or alternative choices for the changes. Explain
+the reasons for choosing the proposed change over these alternative:
+*e.g.* they can be cheaper but insufficient, or better but too
+expensive. Or something else.
+
+The PR discussion often raises other potential designs, and they should be
+added to this section. Similarly, if the proposed change
+specification changes significantly, the old one should be listed in
+this section.
+
+Unresolved Questions
+--------------------
+Explicitly list any remaining issues that remain in the conceptual design and
+specification. Be upfront and trust that the community will help. Please do
+not list *implementation* issues.
+
+Implementation Plan
+-------------------
+(Optional) If accepted who will implement the change? Which other resources
+and prerequisites are required for implementation?
+
+Endorsements
+-------------
+(Optional) This section provides an opportunity for any third parties to express their
+support for the proposal, and to say why they would like to see it adopted.
+It is not mandatory for have any endorsements at all, but the more substantial
+the proposal is, the more desirable it is to offer evidence that there is
+significant demand from the community.  This section is one way to provide
+such evidence.

--- a/rfc/0012-keyless-job-auth.rst
+++ b/rfc/0012-keyless-job-auth.rst
@@ -3,15 +3,9 @@ Keyless Cloud Authentication in Hail Batch Jobs
 ===============================================
 
 .. author:: Daniel Goldstein
-.. date-accepted:: Leave blank. This will be filled in when the proposal is accepted.
-.. ticket-url:: Leave blank. This will eventually be filled with the
-                ticket URL which will track the progress of the
-                implementation of the feature.
-.. implemented:: Leave blank. This will be filled in with the first Hail version which
-                 implements the described feature.
-.. header:: This proposal is `discussed at this pull request <https://github.com/hail-is/hail-rfc/pull/0>`_.
-            **After creating the pull request, edit this file again, update the
-            number in the link, and delete this bold sentence.**
+.. date-accepted:: 2024-02-01
+.. implemented:: https://github.com/hail-is/hail/pull/14019
+.. header:: This proposal is `discussed at this pull request <https://github.com/hail-is/hail-rfc/pull/12>`_.
 .. sectnum::
 .. contents::
 .. role::


### PR DESCRIPTION
This change describes the addition of a user-facing metadata server on the Batch Worker that jobs can use to obtain short-lived access tokens for their cloud credentials without relying on key files injected into the job's filesystem.